### PR TITLE
MSVS 2017 compilation fix

### DIFF
--- a/Easy-PQXX-Win32.bat
+++ b/Easy-PQXX-Win32.bat
@@ -1017,6 +1017,7 @@ if %1 neq 0 (
 echo     ^<ClCompile^>
 echo       ^<AdditionalIncludeDirectories^>$^(MSBuildThisFileDirectory^)include;%%^(AdditionalIncludeDirectories^)^</AdditionalIncludeDirectories^>
 echo       ^<LanguageStandard^>stdcpp17^</LanguageStandard^>
+echo       ^<ConformanceMode^>false^</ConformanceMode^>
 echo     ^</ClCompile^>
 echo     ^<Link^>
 echo       ^<AdditionalLibraryDirectories^>$^(MSBuildThisFileDirectory^)lib\$^(Configuration^);%%^(AdditionalLibraryDirectories^)^</AdditionalLibraryDirectories^>

--- a/Easy-PQXX-patch.bat
+++ b/Easy-PQXX-patch.bat
@@ -1017,6 +1017,7 @@ if %1 neq 0 (
 echo     ^<ClCompile^>
 echo       ^<AdditionalIncludeDirectories^>$^(MSBuildThisFileDirectory^)include;%%^(AdditionalIncludeDirectories^)^</AdditionalIncludeDirectories^>
 echo       ^<LanguageStandard^>stdcpp17^</LanguageStandard^>
+echo       ^<ConformanceMode^>false^</ConformanceMode^>
 echo     ^</ClCompile^>
 echo     ^<Link^>
 echo       ^<AdditionalLibraryDirectories^>$^(MSBuildThisFileDirectory^)lib\$^(Configuration^);%%^(AdditionalLibraryDirectories^)^</AdditionalLibraryDirectories^>

--- a/Easy-PQXX-x64Unicode.bat
+++ b/Easy-PQXX-x64Unicode.bat
@@ -1017,6 +1017,7 @@ if %1 neq 0 (
 echo     ^<ClCompile^>
 echo       ^<AdditionalIncludeDirectories^>$^(MSBuildThisFileDirectory^)include;%%^(AdditionalIncludeDirectories^)^</AdditionalIncludeDirectories^>
 echo       ^<LanguageStandard^>stdcpp17^</LanguageStandard^>
+echo       ^<ConformanceMode^>false^</ConformanceMode^>
 echo     ^</ClCompile^>
 echo     ^<Link^>
 echo       ^<AdditionalLibraryDirectories^>$^(MSBuildThisFileDirectory^)lib\$^(Configuration^);%%^(AdditionalLibraryDirectories^)^</AdditionalLibraryDirectories^>

--- a/Easy-PQXX.bat
+++ b/Easy-PQXX.bat
@@ -1017,6 +1017,7 @@ if %1 neq 0 (
 echo     ^<ClCompile^>
 echo       ^<AdditionalIncludeDirectories^>$^(MSBuildThisFileDirectory^)include;%%^(AdditionalIncludeDirectories^)^</AdditionalIncludeDirectories^>
 echo       ^<LanguageStandard^>stdcpp17^</LanguageStandard^>
+echo       ^<ConformanceMode^>false^</ConformanceMode^>
 echo     ^</ClCompile^>
 echo     ^<Link^>
 echo       ^<AdditionalLibraryDirectories^>$^(MSBuildThisFileDirectory^)lib\$^(Configuration^);%%^(AdditionalLibraryDirectories^)^</AdditionalLibraryDirectories^>

--- a/basic_libpqxx.props
+++ b/basic_libpqxx.props
@@ -12,6 +12,7 @@
     <ClCompile>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)$(Configuration)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <ConformanceMode>false</ConformanceMode>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(MSBuildThisFileDirectory)$(Configuration)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/libpqxx.props
+++ b/libpqxx.props
@@ -12,6 +12,7 @@
     <ClCompile>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <ConformanceMode>false</ConformanceMode>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(MSBuildThisFileDirectory)lib\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/libpqxx_ALL.props
+++ b/libpqxx_ALL.props
@@ -12,6 +12,7 @@
     <ClCompile>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <ConformanceMode>false</ConformanceMode>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(MSBuildThisFileDirectory)lib\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>


### PR DESCRIPTION
MSVS 2017 has a some pretty strange compatibility problems with C++17 code so I decided to create this patch to add a ConformanceMode=**false** property (i.e. disabled **/permissive-** option) as a project defaults.